### PR TITLE
Added option to not fail on scoring exceptions

### DIFF
--- a/bad_score.py
+++ b/bad_score.py
@@ -1,0 +1,33 @@
+import argparse
+
+
+class MalformedOutput(Exception):
+    pass
+
+
+def score(inp, out):
+    raise MalformedOutput("Something went wrong")
+    return 0
+
+
+def solve(seed, inp, log):
+    return '0'
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('inp')
+    parser.add_argument('ans')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = get_args()
+
+    with open(args.inp, 'r') as f:
+        inp = f.read()
+
+    with open(args.ans, 'r') as f:
+        ans = f.read()
+
+    print(score(inp, ans))

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import argparse
 import logging as log
 from random import randint as ri
 from util import mkdir
-from os import link, remove
+from os import remove
 
 
 # Runs scoring function and checks if score is improved.
@@ -15,7 +15,13 @@ def process(inp, out, seed, sc_fun):
     except IOError:
         bsc = 0
 
-    sc = sc_fun(inp, out)
+    try:
+        sc = sc_fun(inp, out)
+    except Exception as e:
+        if not args.ignore:
+            raise
+        log.error(str(e))
+        sc = 0
 
     fmt = 'score: {:<20}'
     # write new output file.
@@ -45,10 +51,11 @@ def process(inp, out, seed, sc_fun):
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('testcase')
-    parser.add_argument('-l', '--log', default='debug')
-    parser.add_argument('-s', '--seed', default=None)
-    parser.add_argument('-n', '--iterations', type=int, default=10)
-    parser.add_argument('--nsspec', action='store', default="solve:score:solve")
+    parser.add_argument('-l', '--log', default='debug', help="set the log level")
+    parser.add_argument('-s', '--seed', default=None, help="provide a seed for the rng")
+    parser.add_argument('-n', '--iterations', type=int, default=10, help="number of iterations to run the solver")
+    parser.add_argument('-i', '--ignore', action='store_true', help="do not fail on scoring errors")
+    parser.add_argument('--nsspec', action='store', default="solve:score:solve", help="specification of the module and functions used to solve and score")
     return parser.parse_args()
 
 


### PR DESCRIPTION
Proposed solution to #10 
- Added help to argparse command line options
- Added '--ignore' flag to log scoring exceptions instead of crashing
- Added bad_score.py to test the new functionality